### PR TITLE
only read edge config if the value is actually used

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,5 +19,9 @@ export default async function middleware(request: Request) {
       status: 403,
       headers: { "Cache-Control": "no-cache" },
     });
-  }  
+  }
+  
+  return next({
+    headers: { "x-your-ip-address": ip || "unknown" },
+  });
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,22 +3,21 @@ import { NextResponse } from "next/server";
 import { get } from "@vercel/edge-config";
 
 export default async function middleware(request: Request) {
-  const blockedIps = (await get("blockedIps")) as string[];
   const ip = ipAddress(request);
-
   const url = new URL(request.url);
   const path = url.pathname;
 
-  if (path === "/am-i-blocked" && ip && blockedIps.includes(ip as string)) {
-    return new NextResponse("Access denied", {
-      status: 403,
-      headers: {
-        "Cache-Control": "no-cache",
-      },
+  if (path !== "/am-i-blocked") {
+    return next({
+      headers: { "x-your-ip-address": ip || "unknown" },
     });
   }
 
-  return next({
-    headers: { "x-your-ip-address": ip || "unknown" },
-  });
+  const blockedIps = await get<string[]>("blockedIps");
+  if (ip && blockedIps.includes(ip as string)) {
+    return new NextResponse("Access denied", {
+      status: 403,
+      headers: { "Cache-Control": "no-cache" },
+    });
+  }  
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,20 +7,16 @@ export default async function middleware(request: Request) {
   const url = new URL(request.url);
   const path = url.pathname;
 
-  if (path !== "/am-i-blocked") {
-    return next({
-      headers: { "x-your-ip-address": ip || "unknown" },
-    });
+  if (path === "/am-i-blocked") {
+    const blockedIps = await get<string[]>("blockedIps");
+    if (ip && blockedIps && blockedIps.includes(ip)) {
+      return new NextResponse("Access denied", {
+        status: 403,
+        headers: { "Cache-Control": "no-cache" },
+      });
+    }
   }
 
-  const blockedIps = await get<string[]>("blockedIps");
-  if (ip && blockedIps.includes(ip as string)) {
-    return new NextResponse("Access denied", {
-      status: 403,
-      headers: { "Cache-Control": "no-cache" },
-    });
-  }
-  
   return next({
     headers: { "x-your-ip-address": ip || "unknown" },
   });


### PR DESCRIPTION
First of all, this demo is absolutely brilliant <picture data-single-emoji=":frog-10:" title=":frog-10:"><img class="emoji" width="20" height="auto" src="https://single-emoji.vercel.app/api/emoji/eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..AR2MiL-1R07T0YNQ.0PHMrzwYgzr6lgWaw603iCmHSCaxW9JxgadWUaXZP8O4EujvUquy3VTbYlwOvGMCO8NjTWkbSeETlrQInzkW0tfzK4HgKn9baYzfjet_4qqglDhqxWAKZqoXinE.jQtJfjD6Mrk8ugPxaUHTGg" alt=":frog-10:" align="absmiddle"></picture> 

I refactored the middleware slightly so it doesn't actually read edge config if we know that the value won't get used.

I rewrote the code through GitHub's editor, and didn't actually run the application to verify it works, so <picture data-single-emoji=":yolo:" title=":yolo:"><img class="emoji" width="20" height="auto" src="https://single-emoji.vercel.app/api/emoji/eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..GL8HTaKVlWWq6JA6.V2CU-Ti4a4duO79XQqqsV27YzJofa4FzyypnaxKD3nOKovufE74ITm2FrF4Wi6uLq2i1VROPa5DErxhq9fJGBv0H4jvcmDZUwLWTIMEgF-6oChU3JrM.LiFETF3b5jDdfAI-6dNpiw" alt=":yolo:" align="absmiddle"></picture> 😄 


_Arguably this makes the code more complicated, so not sure you actually wanna go for it. Happy to close this again too._